### PR TITLE
add pkg/project/project.go

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,0 +1,29 @@
+package project
+
+var (
+	description        = "Repository used in gitrepo tests."
+	gitSHA             = "n/a"
+	name        string = "gitrepo-test"
+	source      string = "https://github.com/giantswarm/gitrepo-test"
+	version            = "0.1.0"
+)
+
+func Description() string {
+	return description
+}
+
+func GitSHA() string {
+	return gitSHA
+}
+
+func Name() string {
+	return name
+}
+
+func Source() string {
+	return source
+}
+
+func Version() string {
+	return version
+}


### PR DESCRIPTION
Towards: giantswarm/giantswarm#8632

Provides testing material for the new `GetProjectVersion` functionnality from https://github.com/giantswarm/gitrepo/pull/18.

NOTE: is it on purpose that `giantswarm/employees` doesn't have access to this repo?